### PR TITLE
fix: 프로필 이미지 링크를 가져오는 객체 변경

### DIFF
--- a/src/auth/srategy/ft-oauth.strategy.ts
+++ b/src/auth/srategy/ft-oauth.strategy.ts
@@ -27,7 +27,7 @@ export class FtOAuthStrategy extends PassportStrategy(Strategy, '42-oauth2') {
         user_id: 'id',
         email: 'email',
         login: 'login',
-        image_url: 'image_url',
+        image_url: 'image.link',
         is_staff: 'staff?',
       },
     });


### PR DESCRIPTION
## 수정 및 작업 내용
- 42 API에서 프로필 이미지를 가져오는 객체가 변경되어 그에 따른 반영

## 사유
- #22
