### PR TITLE
feat: #109 all tag log 수정

### DIFF
--- a/src/tag-log-v1/tag-log.controller.ts
+++ b/src/tag-log-v1/tag-log.controller.ts
@@ -192,6 +192,55 @@ export class TagLogController {
     };
   }
 
+    /**
+   * 특정 월에 대한 모든 로그를 조회합니다.
+   *
+   * @param user 로그인한 사용자 세션
+   * @returns UsageResponseDto
+   */
+    @ApiOperation({
+      summary: '월별 모든 태그로그 조회',
+      description: '월별 모든 태그로그를 조회합니다.',
+    })
+    @ApiResponse({
+      status: 200,
+      type: UserInOutLogsType,
+      description: '조회 성공',
+    })
+    @ApiResponse({ status: 400, description: '쿼리 타입 에러' })
+    @ApiResponse({ status: 401, description: '접근 권한 없음' })
+    @ApiResponse({
+      status: 500,
+      description: '서버 내부 에러 (백앤드 관리자 문의 필요)',
+    })
+    @ApiQuery({
+      name: 'year',
+      description: '년도',
+      required: true,
+    })
+    @ApiQuery({
+      name: 'month',
+      description: '월',
+      required: true,
+    })
+    @Get('alltagpermonth')
+    async getAllTagPerMonth(
+      @User() user: UserSessionDto,
+      @Query('year', ParseIntPipe) year: number,
+      @Query('month', ParseIntPipe) month: number,
+    ): Promise<UserInOutLogsType> {
+      this.logger.debug(`@getPerMonth) ${year}-${month} by ${user.login}`);
+  
+      const date = new Date(`${year}-${month}`);
+  
+      const results = await this.tagLogService.getAllTagPerMonth(user.user_id, date);
+      return {
+        login: user.login,
+        profileImage: user.image_url,
+        inOutLogs: results,
+      };
+    }
+
   /**
    * 로그인한 유저가 메인 화면에 접속할 때 가져올 정보를 반환합니다.
    */

--- a/src/tag-log-v1/tag-log.service.ts
+++ b/src/tag-log-v1/tag-log.service.ts
@@ -360,7 +360,7 @@ export class TagLogService {
           durationSecond,
         });
         temp = null;
-        leave = null;
+        //leave = null;
         //this.logger.debug(`입실 중복`);
         continue;
       }
@@ -393,7 +393,7 @@ export class TagLogService {
           durationSecond,
         });
         leave = null;
-        temp = null;
+        //temp = null;
         //this.logger.debug(`퇴실 중복`);
         continue;
       }

--- a/src/tag-log-v1/tag-log.service.ts
+++ b/src/tag-log-v1/tag-log.service.ts
@@ -256,28 +256,41 @@ export class TagLogService {
 
     const timeLines = taglogs;
 
+    //  const timeLines = taglogs
+    //.sort((a, b) => (a.tag_at < b.tag_at ? 1 : -1));
+    //.map((v) => ({
+    //  tag_at: v.tag_at,
+    //  device_id: v.device_id,
+    //}));
+
     const resultPairs: InOutLogType[] = [];
     
     let temp: TagLogDto | null = null;
     let leave: TagLogDto | null = null;
 
     // 타임라인 배열이 빌 때까지 루프를 돌립니다.
+    //todo: -1이 적용되지 않은 일반배열 받기
+    //그러면 다음날 짝은 밑에서만 맞춰질텐데, 잘 작동하는지가 의문!
     while (timeLines.length > 0) {
       if (temp === null) {
         temp = timeLines.pop();
-        if (temp.idx === -1) {
-          temp = timeLines.pop();
-        }
+      }
+
+      if (temp.idx === -1) {
+        temp = timeLines.pop();
       }
 
       if (timeLines.length <= 0) {
         break;
       }
+      
+      //this.logger.debug(`temp:`, temp.card_id, temp.device_id, temp.idx, temp.tag_at);
+      //temp = null;
 
       // 내부에 있거나 중복 입실태그인 경우
       if (
         this.isInDevice(deviceInfos, temp.device_id)
-      ) {
+        ) {
         const inTimeStamp = this.dateCalculator.toTimestamp(temp.tag_at);
         const outTimeStamp = null;
         const durationSecond = null;
@@ -299,6 +312,10 @@ export class TagLogService {
       if (temp === null) 
         temp = timeLines.pop();
       
+      if (timeLines.length <= 0) {
+        break;
+      }
+
       // 중복 퇴실태그인 경우
       if (
         this.isOutDevice(deviceInfos, temp.device_id)
@@ -311,7 +328,9 @@ export class TagLogService {
           outTimeStamp,
           durationSecond,
         });
-        leave = temp;
+        //leave = temp;
+        //temp = null;
+        leave = null;
         //this.logger.debug(`퇴실 중복`);
         continue;
       }
@@ -355,7 +374,13 @@ export class TagLogService {
           }
           temp = null;
           leave = null;
-        }
+    }
+    
+    //resultPairs.push({
+    //  inTimeStamp: null,
+    //  outTimeStamp: null,
+    //  durationSecond: null,
+    //});
 
     return resultPairs;
   }

--- a/src/tag-log-v1/tag-log.service.ts
+++ b/src/tag-log-v1/tag-log.service.ts
@@ -8,7 +8,6 @@ import { IPairInfoRepository } from './repository/interface/pair-info-repository
 import { ITagLogRepository } from './repository/interface/tag-log-repository.interface';
 import { UserService } from 'src/user/user.service';
 import { InOutDto } from './dto/inout.dto';
-import { time } from 'console';
 
 @Injectable()
 export class TagLogService {
@@ -148,8 +147,6 @@ export class TagLogService {
       }
     }
 
-    //this.logger.debug(`taglogs:`, taglogs[0].tag_at, taglogs[1].tag_at, taglogs[2].tag_at, taglogs[3].tag_at);
-
     return taglogs;
   }
 
@@ -184,9 +181,8 @@ export class TagLogService {
     deviceInfos: PairInfoDto[],
     targetDevice: number,
   ): boolean {
-    
     let ret: boolean = false;
-    
+
     //todo: find하기
     deviceInfos.forEach(deviceInfo => {
       if(deviceInfo.in_device === targetDevice) {
@@ -194,6 +190,7 @@ export class TagLogService {
         ret = true;
       }
     });
+
     return ret;
   }
 
@@ -207,15 +204,15 @@ export class TagLogService {
     deviceInfos: PairInfoDto[],
     targetDevice: number,
   ): boolean {
-    
     let ret: boolean = false;
-    
+
     deviceInfos.forEach(deviceInfo => {
       if(deviceInfo.out_device === targetDevice) {
         this.logger.debug(`@isOutDevice) ${targetDevice}`);
         ret = true;
       }
     });
+
     return ret;
   }
 
@@ -329,9 +326,8 @@ export class TagLogService {
     this.logger.debug(`@getAllPairsByTagLogs)`);
 
     const timeLines = taglogs;
-
     const resultPairs: InOutLogType[] = [];
-    
+
     let temp: TagLogDto | null = null;
     let leave: TagLogDto | null = null;
 
@@ -340,13 +336,11 @@ export class TagLogService {
       if (temp === null) {
         temp = timeLines.pop();
       }
-      
+
       if (timeLines.length <= 0) {
         break;
       }
-      //this.logger.debug(`temp1:`, temp.device_id, temp.tag_at);
 
-      
       // 내부에 있거나 중복 입실태그인 경우
       if (
         this.isInDevice(deviceInfos, temp.device_id)
@@ -360,25 +354,23 @@ export class TagLogService {
           durationSecond,
         });
         temp = null;
-        //leave = null;
         //this.logger.debug(`입실 중복`);
         continue;
       }
-      
+
       if (leave === null) {
         leave = temp;
         temp = null;
       }
-      
+
       if (temp === null) {
         temp = timeLines.pop();
       }
-      
+
       if (timeLines.length <= 0) {
         break;
       }
       //this.logger.debug(`temp2:`, temp.device_id, temp.tag_at);
-
 
       // 중복 퇴실태그인 경우
       if (
@@ -393,7 +385,6 @@ export class TagLogService {
           durationSecond,
         });
         leave = null;
-        //temp = null;
         //this.logger.debug(`퇴실 중복`);
         continue;
       }
@@ -507,8 +498,6 @@ export class TagLogService {
       tagEnd,
       pairs,
     );
-
-    //this.logger.debug(trimmedTagLogs.length);
 
     //짝이 안맞는 로그도 null과 pair를 만들어 반환한다.
     const resultPairs = this.getAllPairsByTagLogs(trimmedTagLogs, pairs);

--- a/src/tag-log-v1/tag-log.service.ts
+++ b/src/tag-log-v1/tag-log.service.ts
@@ -190,7 +190,7 @@ export class TagLogService {
     //todo: find하기
     deviceInfos.forEach(deviceInfo => {
       if(deviceInfo.in_device === targetDevice) {
-        this.logger.debug(`@isInDevice)`);
+        this.logger.debug(`@isInDevice) ${targetDevice}`);
         ret = true;
       }
     });
@@ -212,7 +212,7 @@ export class TagLogService {
     
     deviceInfos.forEach(deviceInfo => {
       if(deviceInfo.out_device === targetDevice) {
-        this.logger.debug(`@isOutDevice)`);
+        this.logger.debug(`@isOutDevice) ${targetDevice}`);
         ret = true;
       }
     });
@@ -340,12 +340,12 @@ export class TagLogService {
       if (temp === null) {
         temp = timeLines.pop();
       }
-
+      
       if (timeLines.length < 0) {
         break;
       }
+      //this.logger.debug(`temp1:`, temp.device_id, temp.tag_at);
 
-      // this.logger.debug(`temp1:`, temp.device_id, temp.tag_at);
       
       // 내부에 있거나 중복 입실태그인 경우
       if (
@@ -360,6 +360,7 @@ export class TagLogService {
           durationSecond,
         });
         temp = null;
+        leave = null;
         //this.logger.debug(`입실 중복`);
         continue;
       }
@@ -376,8 +377,8 @@ export class TagLogService {
       if (timeLines.length < 0) {
         break;
       }
+      //this.logger.debug(`temp2:`, temp.device_id, temp.tag_at);
 
-      // this.logger.debug(`temp2:`, temp.device_id, temp.tag_at);
 
       // 중복 퇴실태그인 경우
       if (
@@ -392,6 +393,7 @@ export class TagLogService {
           durationSecond,
         });
         leave = null;
+        temp = null;
         //this.logger.debug(`퇴실 중복`);
         continue;
       }
@@ -445,7 +447,9 @@ export class TagLogService {
 
     // FIXME: 임시 조치임
     const filteredTagLogs = sortedTagLogs.filter(
-      (v) => v.device_id !== 35 && v.device_id !== 16,
+      (v) => v.device_id !== 35 && v.device_id !== 16 
+      && v.device_id !== 48 && v.device_id !== 49
+      && v.device_id !== 43 && v.device_id !== 44,
     );
 
     const trimmedTagLogs = await this.trimTagLogs(
@@ -492,7 +496,9 @@ export class TagLogService {
 
     // FIXME: 임시 조치임
     const filteredTagLogs = sortedTagLogs.filter(
-      (v) => v.device_id !== 35 && v.device_id !== 16,
+      (v) => v.device_id !== 35 && v.device_id !== 16 
+      && v.device_id !== 48 && v.device_id !== 49
+      && v.device_id !== 43 && v.device_id !== 44,
     );
 
     const trimmedTagLogs = await this.checkAndTrimTagLogs(
@@ -542,7 +548,9 @@ export class TagLogService {
 
     // FIXME: 임시 조치임
     const filteredTagLogs = sortedTagLogs.filter(
-      (v) => v.device_id !== 35 && v.device_id !== 16,
+      (v) => v.device_id !== 35 && v.device_id !== 16 
+      && v.device_id !== 48 && v.device_id !== 49
+      && v.device_id !== 43 && v.device_id !== 44,
     );
 
     const trimmedTagLogs = await this.trimTagLogs(
@@ -588,7 +596,9 @@ export class TagLogService {
 
     // FIXME: 임시 조치임
     const filteredTagLogs = sortedTagLogs.filter(
-      (v) => v.device_id !== 35 && v.device_id !== 16,
+      (v) => v.device_id !== 35 && v.device_id !== 16 
+      && v.device_id !== 48 && v.device_id !== 49
+      && v.device_id !== 43 && v.device_id !== 44,
     );
 
     const trimmedTagLogs = await this.checkAndTrimTagLogs(

--- a/src/tag-log-v1/tag-log.service.ts
+++ b/src/tag-log-v1/tag-log.service.ts
@@ -8,6 +8,7 @@ import { IPairInfoRepository } from './repository/interface/pair-info-repository
 import { ITagLogRepository } from './repository/interface/tag-log-repository.interface';
 import { UserService } from 'src/user/user.service';
 import { InOutDto } from './dto/inout.dto';
+import { time } from 'console';
 
 @Injectable()
 export class TagLogService {
@@ -113,6 +114,7 @@ export class TagLogService {
     
     let ret: boolean = false;
     
+    //todo: find하기
     deviceInfos.forEach(deviceInfo => {
       if(deviceInfo.in_device === targetDevice) {
         this.logger.debug(`@isInDevice)`);
@@ -250,7 +252,7 @@ export class TagLogService {
     taglogs: TagLogDto[],
     deviceInfos: PairInfoDto[],
   ): InOutLogType[] {
-    this.logger.debug(`@getPairsByTagLogs)`);
+    this.logger.debug(`@getAllPairsByTagLogs)`);
 
     const timeLines = taglogs;
 
@@ -261,9 +263,16 @@ export class TagLogService {
 
     // 타임라인 배열이 빌 때까지 루프를 돌립니다.
     while (timeLines.length > 0) {
-      
-      if (temp === null)
+      if (temp === null) {
         temp = timeLines.pop();
+        if (temp.idx === -1) {
+          temp = timeLines.pop();
+        }
+      }
+
+      if (timeLines.length <= 0) {
+        break;
+      }
 
       // 내부에 있거나 중복 입실태그인 경우
       if (
@@ -281,9 +290,14 @@ export class TagLogService {
         //this.logger.debug(`입실 중복`);
         continue;
       }
-
-      leave = temp;
-      temp = timeLines.pop();
+      
+      if (leave === null) {
+        leave = temp;
+        temp = null;
+      }
+      
+      if (temp === null) 
+        temp = timeLines.pop();
       
       // 중복 퇴실태그인 경우
       if (
@@ -336,12 +350,13 @@ export class TagLogService {
           inTimeStamp: this.dateCalculator.toTimestamp(virtualEnterTime),
           outTimeStamp: this.dateCalculator.toTimestamp(leave.tag_at),
           durationSecond: outTimeStamp - virtualInTimeStamp,
-        });
-        //this.logger.debug(`정상 태그 (다른 날)`);
-      }
-      temp = null;
-      leave = null;
-    }
+            });
+            //this.logger.debug(`정상 태그 (다른 날)`);
+          }
+          temp = null;
+          leave = null;
+        }
+
     return resultPairs;
   }
 

--- a/src/tag-log-v1/tag-log.service.ts
+++ b/src/tag-log-v1/tag-log.service.ts
@@ -341,7 +341,7 @@ export class TagLogService {
         temp = timeLines.pop();
       }
       
-      if (timeLines.length < 0) {
+      if (timeLines.length <= 0) {
         break;
       }
       //this.logger.debug(`temp1:`, temp.device_id, temp.tag_at);
@@ -374,7 +374,7 @@ export class TagLogService {
         temp = timeLines.pop();
       }
       
-      if (timeLines.length < 0) {
+      if (timeLines.length <= 0) {
         break;
       }
       //this.logger.debug(`temp2:`, temp.device_id, temp.tag_at);

--- a/src/utils/date-calculator.component.ts
+++ b/src/utils/date-calculator.component.ts
@@ -96,7 +96,7 @@ export class DateCalculator {
    * @return number 타임스탬프
    */
   toTimestamp(date: Date): number {
-    this.logger.debug(`@toTimestamp) ${date}`);
+    //this.logger.debug(`@toTimestamp) ${date}`);
     return Math.floor(date.getTime() / 1000);
   }
 


### PR DESCRIPTION
## 수정 및 작업 내용
- <요약> 500에러 수정했습니다.
- 00시와 23시59분인 가상 로그를 일단 붙인 후 새로운 로직을 적용했을 시 가상 태그로그도 보여 기존 TrimTagLogs 함수에서 checkAndTrimTagLogs 함수를 작성했습니다.
- pop을 2번하는 부분은 그대로 둔 대신, pop이후 스택이 빈 경우 반복문을 종료하는 과정을 추가했습니다.
- 월단위로 페어로그를 가져온다 하셔서 월버전을 추가했습니다.

## 결과
- 많은 양의 디비를 통해 기존 로그와 동일하게 동작하는지 테스트 완료했습니다.
  - [x] 반환 결과 동일
  - [x] 하루 넘어간 로그에 가상 로그 추가
  - [x] 알 수 없는 디바이스 아이디 오류 해결

## 추가
- 데이터베이스 자체에 1태그 1로그가 아닌 경우가 꽤 있는데(ex. 22년 8월 19일~ 23년 2월 9일), 이런 경우 불필요한 정보가 많이 표시될 것 같습니다. 
  - DB에서 중복되는 로그들을 정리하거나, (권장)
  - 불가능하다면 백엔드 로직 내에서 이를 다시 한번 확인하는 로직이 추가로 필요할 것 같습니다.
  - 업데이트 날짜 기준부터만 미싱 태그를 보여주라는 의견도 있었습니다! 👍 (추천!)
- 디바이스ID 확인 중 43-44와 48-49번 디바이스 -> 서초클 계단에 있는 기기 디바이스인것같네요. 로그 정렬 과정에서 무시하는 로직에 추가했습니다.