### PR TITLE
fix: #117 계산 실수 해결

### DIFF
--- a/src/tag-log-v1/tag-log.service.ts
+++ b/src/tag-log-v1/tag-log.service.ts
@@ -505,7 +505,7 @@ export class TagLogService {
     async getTimeSixMonth(userId: number): Promise<number[]> {
       this.logger.debug(`@getTagPerMonth) by ${userId}`);
       const today = new Date();
-      const beforeSixMonth = new Date(today.getFullYear(), today.getMonth() - 5); //todo: check 5
+      const beforeSixMonth = new Date(today.getFullYear(), today.getMonth() - 5); //todo: change to start of month
       const endOfMonth = this.dateCalculator.getEndOfMonth(beforeSixMonth);
 
       const pairs = await this.pairInfoRepository.findAll();
@@ -528,9 +528,10 @@ export class TagLogService {
         monthPairs.forEach(monthPairs => totalSecond += monthPairs.durationSecond);
         
         ret.push(totalSecond);
-  
+        
         beforeSixMonth.setMonth(beforeSixMonth.getMonth() + 1);
         endOfMonth.setMonth(endOfMonth.getMonth() + 1);
+        endOfMonth.setDate(endOfMonth.getDate() - 1);
       }
   
       return ret.reverse();


### PR DESCRIPTION
## 수정 및 작업 내용
- 계산 실수로 달 단위 체류시간 합계를 반환할 때 다음달의 첫 날 로그를 들고오는 이슈가 있었습니다.
