### PR TITLE
feat: #134 카드재발급 exception처리 수정

### DIFF
--- a/src/reissue/reissue.controller.ts
+++ b/src/reissue/reissue.controller.ts
@@ -77,7 +77,7 @@ export class ReissueController {
     description: '신청 성공',
   })
   @ApiResponse({ status: 404, description: '사용자의 기존 카드번호 없음' })
-  @ApiResponse({ status: 503, description: '구글스프레드시트/잔디알림 실패' })
+  @ApiResponse({ status: 503, description: '구글스프레드시트 업데이트 실패' })
   async reissueRequest(
     @User() user: UserSessionDto,
   ): Promise<reissueRequestDto> {

--- a/src/reissue/reissue.controller.ts
+++ b/src/reissue/reissue.controller.ts
@@ -99,7 +99,7 @@ export class ReissueController {
     status: 404,
     description: '사용자의 카드 재발급 신청내역 없음',
   })
-  @ApiResponse({ status: 503, description: '구글스프레드시트/잔디알림 실패' })
+  @ApiResponse({ status: 503, description: '구글스프레드시트 업데이트 실패' })
   async patchReissueState(
     @User() user: UserSessionDto,
   ): Promise<reissueFinishedDto> {

--- a/src/utils/google-api.component.ts
+++ b/src/utils/google-api.component.ts
@@ -1,4 +1,9 @@
-import { Inject, Injectable, Logger, HttpException } from '@nestjs/common';
+import {
+  Inject,
+  Injectable,
+  Logger,
+  ServiceUnavailableException,
+} from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { sheets, auth } from '@googleapis/sheets';
 
@@ -75,9 +80,8 @@ export class GoogleApi {
       this.logger.error(
         `@getAllValues) failed to read google sheet: ${error.message}`,
       );
-      throw new HttpException(
+      throw new ServiceUnavailableException(
         `구글스프레드 시트 조회 실패: ${error.message}`,
-        514,
       );
     }
     return result;
@@ -100,9 +104,8 @@ export class GoogleApi {
       this.logger.error(
         `@appendValues) failed to append to google sheet: ${error.message}`,
       );
-      throw new HttpException(
+      throw new ServiceUnavailableException(
         `카드 재발급 신청 구글스프레드 시트에 추가 실패: ${error.message}`,
-        514,
       );
     }
   }
@@ -124,9 +127,8 @@ export class GoogleApi {
       this.logger.error(
         `@updateValues) failed to update google sheet: ${error.message}`,
       );
-      throw new HttpException(
+      throw new ServiceUnavailableException(
         `수령완료 행 구글스프레드 시트에 업데이트 실패: ${error.message}`,
-        514,
       );
     }
   }

--- a/src/utils/google-api.component.ts
+++ b/src/utils/google-api.component.ts
@@ -1,4 +1,4 @@
-import { Inject, Injectable, Logger } from '@nestjs/common';
+import { Inject, Injectable, Logger, HttpException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { sheets, auth } from '@googleapis/sheets';
 
@@ -71,8 +71,14 @@ export class GoogleApi {
         range: this.gsRange,
       });
       result = allCardReissues.data.values;
-    } catch (e) {
-      this.logger.error(e.message);
+    } catch (error) {
+      this.logger.error(
+        `@getAllValues) failed to read google sheet: ${error.message}`,
+      );
+      throw new HttpException(
+        `구글스프레드 시트 조회 실패: ${error.message}`,
+        514,
+      );
     }
     return result;
   }
@@ -90,8 +96,14 @@ export class GoogleApi {
           values: [data],
         },
       });
-    } catch (e) {
-      this.logger.error(e.message);
+    } catch (error) {
+      this.logger.error(
+        `@appendValues) failed to append to google sheet: ${error.message}`,
+      );
+      throw new HttpException(
+        `카드 재발급 신청 구글스프레드 시트에 추가 실패: ${error.message}`,
+        514,
+      );
     }
   }
 
@@ -108,8 +120,14 @@ export class GoogleApi {
         },
         valueInputOption: 'USER_ENTERED',
       });
-    } catch (e) {
-      this.logger.error(e.message);
+    } catch (error) {
+      this.logger.error(
+        `@updateValues) failed to update google sheet: ${error.message}`,
+      );
+      throw new HttpException(
+        `수령완료 행 구글스프레드 시트에 업데이트 실패: ${error.message}`,
+        514,
+      );
     }
   }
 }


### PR DESCRIPTION
## 수정 및 작업 내용
- 구글 스프레드시트 업데이트 실패시 503 error
- 잔디 알림 실패시 error log/ 응답은 성공 200

## 사유
- 스프레드시트 업데이트 실패는 확인이 필요하여 exception으로 처리
- 잔디 알림은 어드민 영역이라 middleware에서 처리
